### PR TITLE
Fix bad class loaders for AR and POA&M in ConvertSubcommand

### DIFF
--- a/cli-core/pom.xml
+++ b/cli-core/pom.xml
@@ -53,6 +53,16 @@
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/cli-core/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractConvertSubcommand.java
+++ b/cli-core/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractConvertSubcommand.java
@@ -207,4 +207,8 @@ public abstract class AbstractConvertSubcommand
   }
 
   protected abstract Class<?> getLoadedClass();
+  
+  public String getLoadedClassSimpleName() {
+	  return getLoadedClass().getSimpleName();
+  };
 }

--- a/cli-core/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/assessmentresults/ConvertSubcommand.java
+++ b/cli-core/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/assessmentresults/ConvertSubcommand.java
@@ -26,7 +26,7 @@
 
 package gov.nist.secauto.oscal.tools.cli.core.commands.assessmentresults;
 
-import gov.nist.secauto.oscal.lib.model.AssessmentPlan;
+import gov.nist.secauto.oscal.lib.model.AssessmentResults;
 import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractConvertSubcommand;
 
 public class ConvertSubcommand
@@ -38,6 +38,6 @@ public class ConvertSubcommand
 
   @Override
   protected Class<?> getLoadedClass() {
-    return AssessmentPlan.class;
+    return AssessmentResults.class;
   }
 }

--- a/cli-core/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/poam/ConvertSubcommand.java
+++ b/cli-core/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/poam/ConvertSubcommand.java
@@ -26,7 +26,7 @@
 
 package gov.nist.secauto.oscal.tools.cli.core.commands.poam;
 
-import gov.nist.secauto.oscal.lib.model.AssessmentPlan;
+import gov.nist.secauto.oscal.lib.model.PlanOfActionAndMilestones;
 import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractConvertSubcommand;
 
 public class ConvertSubcommand
@@ -38,6 +38,6 @@ public class ConvertSubcommand
 
   @Override
   protected Class<?> getLoadedClass() {
-    return AssessmentPlan.class;
+    return PlanOfActionAndMilestones.class;
   }
 }

--- a/cli-core/src/test/java/gov/nist/secauto/oscal/tools/cli/core/commands/Issue96ClassLoaderTest.java
+++ b/cli-core/src/test/java/gov/nist/secauto/oscal/tools/cli/core/commands/Issue96ClassLoaderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.oscal.tools.cli.core.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class Issue96ClassLoaderTest {
+	/**
+	 * Regression tests for usnistgov/oscal-cli#96. See information at this URL for more details.
+	 * https://github.com/usnistgov/oscal-cli/issues/96
+	 */
+	@Test
+	void testAssessmentPlanClassLoader() {
+		var subcommand = new gov.nist.secauto.oscal.tools.cli.core.commands.assessmentplan.ConvertSubcommand();
+		assertEquals("AssessmentPlan", subcommand.getLoadedClassSimpleName());		
+	}
+
+	@Test
+	void testAssessmentResultsClassLoader() {
+		var subcommand = new gov.nist.secauto.oscal.tools.cli.core.commands.assessmentresults.ConvertSubcommand();
+		assertEquals("AssessmentResults", subcommand.getLoadedClassSimpleName());
+	}
+
+	@Test
+	void testCatalogClassLoader() {
+		var subcommand = new gov.nist.secauto.oscal.tools.cli.core.commands.catalog.ConvertSubcommand();
+		assertEquals("Catalog", subcommand.getLoadedClassSimpleName());
+	}
+
+	@Test
+	void testMappingCollectionClassLoader() {
+		var subcommand = new gov.nist.secauto.oscal.tools.cli.core.commands.mappingcollection.ConvertSubcommand();
+		assertEquals("MappingCollection", subcommand.getLoadedClassSimpleName());
+	}
+	
+	@Test
+	void testPoamClassLoader() {
+		var subcommand = new gov.nist.secauto.oscal.tools.cli.core.commands.poam.ConvertSubcommand();
+		assertEquals("PlanOfActionAndMilestones", subcommand.getLoadedClassSimpleName());
+	}
+	
+	@Test
+	void testSspClassLoader() {
+		var subcommand = new gov.nist.secauto.oscal.tools.cli.core.commands.ssp.ConvertSubcommand();
+		assertEquals("SystemSecurityPlan", subcommand.getLoadedClassSimpleName());
+	}
+}


### PR DESCRIPTION
# Committer Notes

Fix bad class loaders for AR and POA&M in ConvertSubcommand classes for #96.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-cli/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website and readme documentation affected by the changes you made?~
