### PR TITLE
Main builds are not needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     # -------------------------
     - name: Deploy Maven Artifact SNAPSHOTs
       run: |
-        mvn -s $GITHUB_WORKSPACE/settings.xml -Pgpg -Preporting deploy
+        mvn -s $GITHUB_WORKSPACE/settings.xml -Pgpg -Preporting -dmaven.deploy.skip=releases deploy
       env:
         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-    - main
     - develop
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     # -------------------------
     - name: Deploy Maven Artifact SNAPSHOTs
       run: |
-        mvn -s $GITHUB_WORKSPACE/settings.xml -Pgpg -Preporting -dmaven.deploy.skip=releases deploy
+        mvn -s $GITHUB_WORKSPACE/settings.xml -Pgpg -Preporting -Dmaven.deploy.skip=releases deploy
       env:
         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
# Committer Notes

This creates extra artifact deployments that are not needed.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-cli/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website and readme documentation affected by the changes you made?~
