### PR TITLE
Add overwrite argument for profile resolution subcommand

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/profile/ResolveSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/profile/ResolveSubcommand.java
@@ -92,10 +92,17 @@ public class ResolveSubcommand
           .desc("convert to format: xml, json, or yaml")
           .build());
   @NonNull
+  private static final Option OVERWRITE_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("overwrite")
+          .desc("overwrite the destination if it exists")
+          .build());          
+  @NonNull
   private static final List<Option> OPTIONS = ObjectUtils.notNull(
       List.of(
           AS_OPTION,
-          TO_OPTION));
+          TO_OPTION,
+          OVERWRITE_OPTION));
 
   @Override
   public String getName() {
@@ -227,7 +234,7 @@ public class ResolveSubcommand
 
     if (destination != null) {
       if (Files.exists(destination)) {
-        if (!cmdLine.hasOption("overwrite")) {
+        if (!cmdLine.hasOption(OVERWRITE_OPTION)) {
           return ExitCode.FAIL.exitMessage("The provided destination '" + destination
               + "' already exists and the --overwrite option was not provided.");
         }


### PR DESCRIPTION
# Committer Notes

Add overwrite argument for profile resolution subcommand. Closes #79.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-cli/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? (See issue)
- ~Have you written new tests for your core changes, as applicable?~
- [x] Have you included examples of how to use your new feature(s)?
- ~Have you updated all website and readme documentation affected by the changes you made?~
