### PR TITLE
[WIP] Disabled signing and deployment to Maven Central for "develop" branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         mvn -B -e -Prelease -Preporting install
     - name: Build, Test and DEPLOY SNAPSHOT Code
-      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'develop'
+      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       run: |
         mvn -B -e -Pgpg -Prelease -Preporting deploy -Dmaven.deploy.skip=releases
       env:


### PR DESCRIPTION
# Committer Notes

This branch is for us to fix the build errors we are experiencing. This initial PR is designed simply to disable mvn central deployment for the develop branch.

### All Submissions:

- [X] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [X] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-cli/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

N/A
