### PR TITLE
Fix convert help subcommand error for #210

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/oscal/AbstractOscalConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/oscal/AbstractOscalConvertSubcommand.java
@@ -29,15 +29,55 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.oscal;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.cli.commands.AbstractConvertSubcommand;
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+import gov.nist.secauto.metaschema.model.common.util.ObjectUtils;
 import gov.nist.secauto.oscal.lib.OscalBindingContext;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import java.util.Collection;
+import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractOscalConvertSubcommand
     extends AbstractConvertSubcommand {
+
+  @NonNull
+  private static final Option OVERWRITE_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("overwrite")
+          .desc("overwrite the destination if it exists")
+          .build());
+
+  @NonNull
+  private static final Option TO_OPTION = ObjectUtils.notNull(
+      Option.builder()
+          .longOpt("to")
+          .hasArg().argName("FORMAT")
+          .desc("convert to format: xml, json, or yaml")
+          .build());
+
+  @Override
+  public Collection<? extends Option> gatherOptions() {
+    return ObjectUtils.notNull(List.of(
+        OVERWRITE_OPTION,
+        TO_OPTION));
+  }
+
+  @Override
+  public void validateOptions(CallingContext callingContext, CommandLine cmdLine)
+      throws InvalidArgumentException {
+    if (cmdLine.hasOption("help") || cmdLine.hasOption("version")) {
+      return;
+    }
+
+    if (!cmdLine.hasOption("to")) {
+      throw new InvalidArgumentException("Missing required option: to");
+    }
+  }
 
   @NonNull
   public abstract Class<?> getOscalClass();

--- a/src/test/java/gov/nist/secauto/oscal/tools/cli/core/CLITest.java
+++ b/src/test/java/gov/nist/secauto/oscal/tools/cli/core/CLITest.java
@@ -84,8 +84,7 @@ public class CLITest {
 
     for (String cmd : commands) {
       values.add(Arguments.of(new String[] { cmd, "validate", "-h" }, ExitCode.OK, null));
-      // TODO: Update when usnistgov/oscal-cli#210 fix merged.
-      values.add(Arguments.of(new String[] { cmd, "convert", "-h" }, ExitCode.INVALID_COMMAND, null));
+      values.add(Arguments.of(new String[] { cmd, "convert", "-h" }, ExitCode.OK, null));
 
       for (Format format : Format.values()) {
         path = Paths.get("src/test/resources/cli/example_" + cmd + "_invalid" + format.getDefaultExtension());


### PR DESCRIPTION
# Committer Notes

Closes #210.

The convert subcommand was throwing an error when invoked with --help, instead of displaying the help message and returning exit code 0. This occurred because the parent class marked the --to option as required, causing parsing to fail before help could be displayed.

This fix overrides gatherOptions() to define the --to option without marking it as required, and implements validateOptions() to skip validation when --help or --version is present. For normal convert operations, --to is still validated manually to ensure it's provided.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/usnistgov/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-cli/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~ N/A
- ~Have you updated all website and readme documentation affected by the changes you made?~ N/A